### PR TITLE
Override of default mapping between event and handler now possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,36 @@ public class NewCustomerEventHandler : IEventGridHandler {
 	}
 }
 ```
+## Custom mapping
+To use a custom mapping, create your own implementation of ShartEventGridMapper.
+The following mapper, will map based on a convention that the eventhandler must start with {eventsubject}_
+
+```cs
+    public class SubjectConventionMapper : EventGridMapper
+    {
+        private readonly Dictionary<string, List<Type>> handlers = new Dictionary<string, List<Type>>();
+
+        public override void AddMapping(string eventType, Type type)
+        {
+            if (handlers.Any(h => h.Key == eventType.ToLower()))
+                handlers[eventType].Add(type);
+            else
+                handlers.Add(eventType.ToLower(), new List<Type> { type });
+        }
+
+        public override Type LookUpMapping(Event item)
+        {
+            var key = item.EventType.ToLower();
+            if (handlers.ContainsKey(key) && handlers[key].Any(t => t.Name.StartsWith(item.Subject + "_")))
+                return handlers[key].First(t => t.Name.StartsWith(item.Subject + "_"));
+            return null;
+        }
+    }
+```
+
+To use the new mapper, add it to the EventGridOptions
+
+```cs
+opt.Mapper=new SubjectConventionMapper();
+```
+

--- a/SharpEventGridServer.sln
+++ b/SharpEventGridServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26923.0
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpEventGridServer", "SharpEventGridServer\SharpEventGridServer.csproj", "{AE0D64BC-F59D-42F4-8533-F7724F1410BB}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{46039ACF-7
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpMappingOverrideSample", "SharpMappingOverrideSample\SharpMappingOverrideSample.csproj", "{553B96A6-9C1B-4182-8BA4-5590BCD59860}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +28,10 @@ Global
 		{97BC76E8-A746-4F28-BC38-701648ED78EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97BC76E8-A746-4F28-BC38-701648ED78EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97BC76E8-A746-4F28-BC38-701648ED78EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{553B96A6-9C1B-4182-8BA4-5590BCD59860}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{553B96A6-9C1B-4182-8BA4-5590BCD59860}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{553B96A6-9C1B-4182-8BA4-5590BCD59860}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{553B96A6-9C1B-4182-8BA4-5590BCD59860}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpEventGridServer/EventGridMapper.cs
+++ b/SharpEventGridServer/EventGridMapper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SharpEventGrid;
+
+namespace SharpEventGridServer
+{
+    public class EventGridMapper
+    {
+        private readonly Dictionary<string, Type> handlers = new Dictionary<string, Type>();
+
+        public virtual void AddMapping(string eventType, Type type)
+        {
+            handlers.Add(eventType.ToLower(), type);
+        }
+
+        public virtual Type LookUpMapping(Event item)
+        {
+            var resulttype = handlers.FirstOrDefault(i => i.Key == item.EventType.ToLower());
+            return resulttype.Equals(default(KeyValuePair<string, Type>)) ? null : resulttype.Value;
+        }
+    }
+}

--- a/SharpEventGridServer/EventGridOptions.cs
+++ b/SharpEventGridServer/EventGridOptions.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using SharpEventGrid;
 
-namespace SharpEventGridServer {
-    public class EventGridOptions {
-        private Type _defaultMapping;
-        private Dictionary<string, Type> _handlers = new Dictionary<string, Type>();
+namespace SharpEventGridServer
+{
+    public class EventGridOptions
+    {
+        protected Type _defaultMapping;
+
         internal IServiceProvider ServiceProvider { get; set; }
 
         public string EventsPath { get; set; } = "api/events";
@@ -14,22 +15,27 @@ namespace SharpEventGridServer {
         public string ValidationKey { get; set; }
         public string ValidationValue { get; set; }
         public Action<string, bool, string> AutoValidateSubscriptionAttemptNotifier { get; set; }
-
-        public void MapEvent<T>(string eventType) where T : IEventGridHandler {
-            _handlers.Add(eventType.ToLower(), typeof(T));
+        public EventGridMapper Mapper = new EventGridMapper();
+        public virtual void MapEvent<T>(string eventType) where T : IEventGridHandler
+        {
+            Mapper.AddMapping(eventType, typeof(T));
         }
-        public void MapDefault<T>() where T : IEventGridHandler {
+        public void MapDefault<T>() where T : IEventGridHandler
+        {
             _defaultMapping = typeof(T);
         }
 
-        public void SetValidationKey(string key, string value) {
+        public void SetValidationKey(string key, string value)
+        {
             ValidationKey = key;
             ValidationValue = value;
         }
 
-        internal IEventGridHandler ResolveHandler(Event item) {
-            var key = item.EventType.ToLower();
-            Type typeToCreate = _handlers.ContainsKey(key) ? _handlers[key] : _defaultMapping;
+        internal virtual IEventGridHandler ResolveHandler(Event item)
+        {
+            var typeToCreate = Mapper.LookUpMapping(item);
+            if (typeToCreate == null)
+                typeToCreate = _defaultMapping;
             var handler = ServiceProvider.GetService(typeToCreate) ?? Activator.CreateInstance(typeToCreate);
             return (IEventGridHandler)handler;
         }

--- a/SharpEventGridServer/SharpEventGridServer.csproj
+++ b/SharpEventGridServer/SharpEventGridServer.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
     <PackageReference Include="SharpEventGrid" Version="1.1.0" />
   </ItemGroup>

--- a/SharpMappingOverrideSample/Controllers/SendEventsController.cs
+++ b/SharpMappingOverrideSample/Controllers/SendEventsController.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using SharpEventGrid;
+
+namespace SharpMappingOverrideSample {
+    public class SendEventsController : Controller {
+        private readonly HttpClient _client;
+
+        public SendEventsController(HttpClient client) {
+            _client = client;
+        }
+
+        [HttpGet("api/test/subscription")]
+        public async Task<IActionResult> TestSubscription() {
+            var response = await SendEvent(EventTypes.SubscriptionValidationEvent, new ValidationEvent { ValidationCode = "foo" });
+            return Ok(response);
+        }
+        
+        [HttpGet("api/test/event")]
+        public async Task<IActionResult> TestEvent(string eventType, string message) {
+            var response = await SendEvent(eventType, message);
+            return Ok(response);
+        }
+        private async Task<string> SendEvent(string eventType, object data) {
+            var url = $"{Request.Scheme}://{Request.Host.Value}/api/events?{Request.QueryString}";
+            var item = new Event {
+                EventType = eventType,
+                Subject = "mySubject",
+                Data = data
+            };
+            var json = JsonConvert.SerializeObject(new List<Event> { item });
+            var response = await _client.PostAsync(url, new StringContent(json));
+            var body = await response.Content.ReadAsStringAsync();
+            if (String.IsNullOrEmpty(body)) {
+                body = "OK";
+            }
+            return body;
+        }
+    }
+}

--- a/SharpMappingOverrideSample/EventHandlers/DefaultMappingHandler.cs
+++ b/SharpMappingOverrideSample/EventHandlers/DefaultMappingHandler.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using SharpEventGrid;
+using SharpEventGridServer;
+
+namespace SharpMappingOverrideSample {
+    public class DefaultMappingHandler : IEventGridHandler {
+        public async Task ProcessEvent(Event eventItem) {
+            Debug.WriteLine($"{nameof(DefaultMappingHandler)} {eventItem.EventType}");
+        }
+    }
+}

--- a/SharpMappingOverrideSample/EventHandlers/mySubject_NewCustomerEventHandler.cs
+++ b/SharpMappingOverrideSample/EventHandlers/mySubject_NewCustomerEventHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using SharpEventGrid;
+using SharpEventGridServer;
+
+namespace SharpMappingOverrideSample {
+    public class mySubject_NewCustomerEventHandler : IEventGridHandler {
+
+        private IDatabase _database;
+        public mySubject_NewCustomerEventHandler(IDatabase database) {
+            _database = database;
+        }
+
+        public async Task ProcessEvent(Event eventItem) {
+            var newCustomerEvent = eventItem.DeserializeEvent<NewCustomerEvent>();
+            await _database.SaveAsync(newCustomerEvent);
+            Debug.WriteLine($"{nameof(mySubject_NewCustomerEventHandler)} {eventItem.EventType}");
+        }
+    }
+}

--- a/SharpMappingOverrideSample/EventHandlers/mySubject_SomeEventHandler.cs
+++ b/SharpMappingOverrideSample/EventHandlers/mySubject_SomeEventHandler.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using SharpEventGrid;
+using SharpEventGridServer;
+
+namespace SharpMappingOverrideSample {
+    public class mySubject_SomeEventHandler : IEventGridHandler {
+        public async Task ProcessEvent(Event eventItem) {
+            Debug.WriteLine($"{nameof(mySubject_SomeEventHandler)} {eventItem.EventType}");
+        }
+    }
+}

--- a/SharpMappingOverrideSample/NewCustomerEvent.cs
+++ b/SharpMappingOverrideSample/NewCustomerEvent.cs
@@ -1,0 +1,5 @@
+﻿namespace SharpMappingOverrideSample {
+    public class NewCustomerEvent {
+
+    }
+}

--- a/SharpMappingOverrideSample/Program.cs
+++ b/SharpMappingOverrideSample/Program.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace SharpMappingOverrideSample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/SharpMappingOverrideSample/Properties/launchSettings.json
+++ b/SharpMappingOverrideSample/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:29119/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SharpEventGridServerSample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:29120/"
+    }
+  }
+}

--- a/SharpMappingOverrideSample/Services/Database.cs
+++ b/SharpMappingOverrideSample/Services/Database.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace SharpMappingOverrideSample {
+    public class Database : IDatabase {
+        public async Task SaveAsync(object item) {
+            //example
+        }
+    }
+}

--- a/SharpMappingOverrideSample/Services/IDatabase.cs
+++ b/SharpMappingOverrideSample/Services/IDatabase.cs
@@ -1,0 +1,7 @@
+﻿using System.Threading.Tasks;
+
+namespace SharpMappingOverrideSample {
+    public interface IDatabase {
+        Task SaveAsync(object item);
+    }
+}

--- a/SharpMappingOverrideSample/SharpMappingOverrideSample.csproj
+++ b/SharpMappingOverrideSample/SharpMappingOverrideSample.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpEventGridServer\SharpEventGridServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SharpMappingOverrideSample/Startup.cs
+++ b/SharpMappingOverrideSample/Startup.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SharpEventGridServer;
+
+namespace SharpMappingOverrideSample {
+    public class Startup {
+        public Startup(IConfiguration configuration) {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services) {
+            services.AddSingleton(new HttpClient());
+            services.AddSingleton(new mySubject_SomeEventHandler());
+            services.AddSingleton<IDatabase, Database>();
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env) {
+            if (env.IsDevelopment()) {
+                app.UseDeveloperExceptionPage();
+            }
+            var opt = new EventGridOptions();
+            opt.AutoValidateSubscription = true;
+            opt.AutoValidateSubscriptionAttemptNotifier = (url, success, message) => {
+                Debug.WriteLine($"Validation attempt: {url} -> Success: {success}: {message}");
+            };
+            opt.EventsPath = "api/events";
+            opt.MapEvent<mySubject_SomeEventHandler>("someEventType");
+            opt.MapEvent<mySubject_NewCustomerEventHandler>("newCustomerEventType");
+            opt.MapDefault<DefaultMappingHandler>();
+            opt.SetValidationKey("key", "foo");
+            app.UseEventGrid(opt);
+            opt.Mapper=new SubjectConventionMapper();
+            app.UseMvc();
+        }
+    }
+}

--- a/SharpMappingOverrideSample/SubjectConventionMapper.cs
+++ b/SharpMappingOverrideSample/SubjectConventionMapper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SharpEventGrid;
+using SharpEventGridServer;
+
+namespace SharpMappingOverrideSample
+{
+    public class SubjectConventionMapper : EventGridMapper
+    {
+        private readonly Dictionary<string, List<Type>> handlers = new Dictionary<string, List<Type>>();
+
+        public override void AddMapping(string eventType, Type type)
+        {
+            if (handlers.Any(h => h.Key == eventType.ToLower()))
+                handlers[eventType].Add(type);
+            else
+                handlers.Add(eventType.ToLower(), new List<Type> { type });
+        }
+
+        public override Type LookUpMapping(Event item)
+        {
+            var key = item.EventType.ToLower();
+            if (handlers.ContainsKey(key) && handlers[key].Any(t => t.Name.StartsWith(item.Subject + "_")))
+                return handlers[key].First(t => t.Name.StartsWith(item.Subject + "_"));
+            return null;
+        }
+    }
+}

--- a/SharpMappingOverrideSample/appsettings.Development.json
+++ b/SharpMappingOverrideSample/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/SharpMappingOverrideSample/appsettings.json
+++ b/SharpMappingOverrideSample/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi

It would be nice if it was possible to customize the mapping. For example be able to map based on a convention saying that the eventhandler must start with subject from event.
I've refactored the EventGridOptions to take a mapper, then one can extend the maping with own requirements